### PR TITLE
Output exact hub url

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,11 @@ def create_app() -> Flask:
     def hub():
         return send_from_directory(app.template_folder, "hub.html")
 
+    # Alias-Route für direkte Links wie /hub
+    @app.get("/hub")
+    def hub_alias():
+        return send_from_directory(app.template_folder, "hub.html")
+
     @app.get("/pendel")
     def pendel():
         return send_from_directory(app.template_folder, "index.html")


### PR DESCRIPTION
Add an alias route for `/hub` to serve `hub.html` to prevent "Not Found" errors when users access the hub directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3da169aa-bdb7-43fd-8c7a-311b5a907eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3da169aa-bdb7-43fd-8c7a-311b5a907eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

